### PR TITLE
Feat/user uploaded avatars support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A lightweight social media dashboard where users can track analytics from variou
 
 ## TODO
 
-### General
+### DEV
+
+#### General
 
 - Deploy
 - README structure
@@ -16,14 +18,14 @@ A lightweight social media dashboard where users can track analytics from variou
 - Containerization
 - SonarQube?
 
-### Frontend
+#### Frontend
 
 - ...
 
-### Backend
+#### Backend
 
-- Avatars storage methods (cloudinary?)
-- Environment Variable Validation (envalid) 
+- Sanitization
+- Environment Variable Validation 
 - Routes protection
 - Data Storage (Redis)
 - Traffic Management
@@ -32,3 +34,67 @@ A lightweight social media dashboard where users can track analytics from variou
 - Testing
 - Compression
 - Database Query Optimization
+
+### APP FEATURES
+
+#### 1. Account analytics
+
+**Main:**
+- total number of posts
+- total number of followers
+- total number of the followed
+- user profile picture (?)
+- most popular posts / photos (?)
+
+**Additional:**
+- weekly increase in followers
+- weekly increase in followed
+- weekly increase in likes
+- weekly increase in comments
+- daily / monthly / yearly follower growth (increase or decrease)
+- daily / monthly / yearly followed growth (increase or decrease)
+- daily / monthly / yearly likes growth
+- daily / monthly / yearly comments growth
+
+#### 2. Post Analytics
+
+**Main:**
+- …
+
+**Additional:**
+- followers reach rate*
+- post reach per day / month / year
+- positive and negative reactions per day / month / year
+- comments per day / month / year
+- reposts / shares per day / month / year
+- text messages
+- reach by media product type for last 30 days (posts, stories, reels, other)
+
+#### 3. Audience Insights
+
+**Main:**
+- followers by location (country / city)
+- followers by age group
+- followers by gender
+- most popular content by country
+- most popular content by age group
+- most popular content by gender
+- language preference
+
+**Additional:**
+- time of day activity
+
+#### 4. Content Overview
+
+**Main:**
+- photo
+- title
+- date
+- number of views
+- number of comments
+- number of likes
+
+**Additional:**
+- details (?)
+
+*followers reach rate is the total reach of page followers during the last 30 days divided by the current total number of followers. The closer this metric is to 100% the better

--- a/package-lock.json
+++ b/package-lock.json
@@ -3700,6 +3700,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
@@ -4162,6 +4172,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -4406,6 +4422,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4532,6 +4565,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.6.0.tgz",
+      "integrity": "sha512-FIlny9RR5LPgkMioG4V7yUpC6ASyIFQMWfx4TgOi/xBeLxJTegbyQc3itiXL0b0lDlSaL0KyT2THEw6osrKqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4619,6 +4665,51 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.1.2",
@@ -4730,6 +4821,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -6112,6 +6209,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6533,6 +6636,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -6732,6 +6844,36 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7136,6 +7278,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7173,6 +7321,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -7907,6 +8066,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -8183,6 +8350,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.2",
@@ -8535,6 +8708,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8646,6 +8828,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cloudinary": "^2.6.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -8653,6 +8836,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.12.1",
         "morgan": "^1.10.0",
+        "multer": "^1.4.5-lts.2",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.17.0",
         "yamljs": "^0.3.0",
@@ -8665,6 +8849,7 @@
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/morgan": "^1.9.9",
+        "@types/multer": "^1.4.12",
         "@types/node": "^20.11.24",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/yamljs": "^0.2.34",

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,6 @@ LOG_LEVEL=http
 DATABASE_URI=database_uri
 ACCESS_TOKEN_SECRET=access_token_secret
 REFRESH_TOKEN_SECRET=refresh_token_secret
+CLOUDINARY_CLOUD_NAME=cloudinary_cloud_name
+CLOUDINARY_API_KEY=cloudinary_api_key
+CLOUDINARY_API_SECRET=cloudinary_api_secret

--- a/server/app.ts
+++ b/server/app.ts
@@ -5,23 +5,25 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 
 import connectDb from "configs/db.config.ts";
-import authRouter from "routes/auth.route.ts";
+import setupSwagger from "configs/swagger.config.ts";
 import verifyJWT from "middlewares/auth.verifyJWT.middleware.ts";
-import morganLogger from "middlewares/morgan.middleware.ts";
+import requestLogger from "middlewares/requestLogger.middleware.ts";
+import authRouter from "routes/auth.route.ts";
+import userRoute from "routes/users.route.ts";
 
 connectDb();
 
 const app = express();
 
+setupSwagger(app);
+
 app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
-app.use(morganLogger);
+app.use(requestLogger);
 
 app.use("/api/auth", authRouter);
-
-app.use(verifyJWT);
-// Protected endpoints
+app.use("/api/users", verifyJWT, userRoute);
 
 app.use((req, res, next) => {
   res.status(404).json({ error: "Endpoint not found" });

--- a/server/configs/uploadMedia.config.ts
+++ b/server/configs/uploadMedia.config.ts
@@ -1,0 +1,9 @@
+import { v2 as cloudinary } from "cloudinary";
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+export default cloudinary;

--- a/server/controllers/auth/auth.login.controller.ts
+++ b/server/controllers/auth/auth.login.controller.ts
@@ -44,7 +44,7 @@ export const login = async (req: Request, res: Response) => {
     foundUser.refreshToken = refreshToken;
     await foundUser.save();
 
-    res.cookie("refreshToken", refreshToken, refreshTokenCookieOptions);
+    res.cookie("refresh_token", refreshToken, refreshTokenCookieOptions);
 
     return res.status(200).json({ accessToken });
   } catch (error) {

--- a/server/controllers/auth/auth.logout.controller.ts
+++ b/server/controllers/auth/auth.logout.controller.ts
@@ -14,11 +14,11 @@ export const logout = async (req: Request, res: Response) => {
     const foundUser = await User.findOne({ refreshToken });
 
     if (foundUser) {
-      foundUser.refreshToken = undefined;
+      foundUser.refreshToken = null;
       await foundUser.save();
     }
 
-    res.clearCookie("refreshToken", {
+    res.clearCookie("refresh_token", {
       ...refreshTokenCookieOptions,
     });
 

--- a/server/controllers/auth/auth.register.controller.ts
+++ b/server/controllers/auth/auth.register.controller.ts
@@ -41,7 +41,7 @@ export const register = async (req: Request, res: Response) => {
     newUser.refreshToken = refreshToken;
     await newUser.save();
 
-    res.cookie("refreshToken", refreshToken, refreshTokenCookieOptions);
+    res.cookie("refresh_token", refreshToken, refreshTokenCookieOptions);
 
     return res.status(201).json({ accessToken });
   } catch (error) {

--- a/server/controllers/users/getCurrentUser.controller.ts
+++ b/server/controllers/users/getCurrentUser.controller.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express";
+
+import User, { PUBLIC_USER_FIELDS } from "models/user.model.ts";
+
+const getCurrentUser = async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const user = await User.findById(userId).select(PUBLIC_USER_FIELDS);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    res.status(200).json(user);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error fetching user data:", error.message);
+      res.status(500).json({ error: "Failed to fetch user data" });
+    }
+  }
+};
+
+export default getCurrentUser;

--- a/server/controllers/users/updateUser.controller.ts
+++ b/server/controllers/users/updateUser.controller.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from "express";
+import { UploadApiResponse } from "cloudinary";
+import { z } from "zod";
+
+import cloudinary from "configs/uploadMedia.config.ts";
+import User, { PUBLIC_USER_FIELDS } from "models/user.model.ts";
+import { userSchema } from "schemas/user.schema.ts";
+
+const updateUser = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+
+    const { username, lastName, firstName } = userSchema.update.parse(req.body);
+
+    const user = await User.findById(userId).select(PUBLIC_USER_FIELDS);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    if (req.file) {
+      try {
+        const result = await new Promise<UploadApiResponse>(
+          (resolve, reject) => {
+            const stream = cloudinary.uploader.upload_stream(
+              { folder: "user-avatars" },
+              (error, response) => {
+                if (error) {
+                  return reject(error);
+                }
+
+                if (!response) {
+                  return reject("No response from Cloudinary");
+                }
+
+                resolve(response);
+              },
+            );
+
+            stream.end(req.file?.buffer);
+          },
+        );
+
+        user.avatar = result.secure_url;
+      } catch (error) {
+        return res.status(500).json({ error });
+      }
+    }
+
+    if (username) user.username = username;
+    if (firstName) user.firstName = firstName;
+    if (lastName) user.lastName = lastName;
+
+    await user.save();
+
+    // TODO: Temp solution. The user is queried the second time to avoid responding with additional automatically set updatedAt property after saving
+    const updatedUser = await User.findById(userId).select(PUBLIC_USER_FIELDS);
+
+    res.status(200).json(updatedUser);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ errors: error });
+    }
+
+    res.status(500).json({ error: "An unexpected error occurred." });
+  }
+};
+
+export default updateUser;

--- a/server/docs/openapi.yaml
+++ b/server/docs/openapi.yaml
@@ -198,7 +198,7 @@ paths:
                     example: "No refresh token present."
         '500':
           $ref: "#/components/responses/500UnexpectedError"
-  /api/auth/refreshToken:
+  /api/auth/refresh-token:
     post:
       summary: "Refresh access token"
       description: "Endpoint to refresh a user's expired access token using a valid refresh token"
@@ -235,5 +235,166 @@ paths:
                   message:
                     type: string
                     description: "nvalid refresh token or user not found."
+        '500':
+          $ref: "#/components/responses/500UnexpectedError"
+  /api/users/current:
+    get:
+      summary: Get current user
+      description: Retrieve the details of the currently authenticated user.
+      tags:
+        - Users
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '200':
+          description: Successfully retrieved user information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: The unique identifier for the user.
+                    example: "64f0c7b6ee1d4d001adf4e12"
+                  username:
+                    type: string
+                    description: The user's username.
+                    example: "john_doe"
+                  firstName:
+                    type: string
+                    description: The user's first name.
+                    example: "John"
+                  lastName:
+                    type: string
+                    description: The user's last name.
+                    example: "Doe"
+                  avatar:
+                    type: string
+                    format: url
+                    description: The URL of the user's avatar.
+                    example: "https://cloudinary.com/path-to-avatar-image"
+        '401':
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+                    example: "Unauthorized"
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+                    example: "User not found."
+        '500':
+          $ref: "#/components/responses/500UnexpectedError"
+
+  /api/users/{userId}:
+    patch:
+      summary: Update a user
+      description: Update a user's information, such as `username`, `firstName`, `lastName`, or upload a new profile picture (`avatar`).
+      tags:
+        - Users
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          description: The unique identifier for the user to be updated.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                  minLength: 4
+                  maxLength: 20
+                  pattern: "^[a-zA-Z0-9_]+$"
+                  description: Username must be at least 4 characters long and must not exceed 20 characters. 
+                    It can only contain letters, numbers, and underscores.
+                firstName:
+                  type: string
+                  minLength: 1
+                  maxLength: 50
+                  description: First name must not be empty. It must not exceed 50 characters.
+                lastName:
+                  type: string
+                  maxLength: 50
+                  description: Last name must not exceed 50 characters.
+                avatar:
+                  type: string
+                  format: binary
+                  description: File must be an image of type PNG, JPEG, JPG, SVG, or GIF. Its size must not exceed 3MB.
+      responses:
+        '200':
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: The unique identifier for the user.
+                  username:
+                    type: string
+                    description: The user's username.
+                  firstName:
+                    type: string
+                    description: The first name of the user.
+                  lastName:
+                    type: string
+                    description: The last name of the user (if provided).
+                  avatar:
+                    type: string
+                    format: url
+                    description: URL for the user's avatar.
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Validation failed.
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                          example: firstName
+                        message:
+                          type: string
+                          example: "First name is required."
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User not found."
         '500':
           $ref: "#/components/responses/500UnexpectedError"

--- a/server/global.d.ts
+++ b/server/global.d.ts
@@ -1,0 +1,8 @@
+declare namespace Express {
+  export interface Request {
+    user?: {
+      id: string;
+      username: string;
+    };
+  }
+}

--- a/server/middlewares/auth.verifyJWT.middleware.ts
+++ b/server/middlewares/auth.verifyJWT.middleware.ts
@@ -1,11 +1,12 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 
-interface CustomRequest extends Request {
-  user?: any;
-}
+type JWTUserData = {
+  id: string;
+  username: string;
+};
 
-const verifyJWT = (req: CustomRequest, res: Response, next: NextFunction) => {
+const verifyJWT = (req: Request, res: Response, next: NextFunction) => {
   const bearerToken = req.headers.authorization?.split(" ")[1];
 
   if (!bearerToken) {
@@ -15,7 +16,10 @@ const verifyJWT = (req: CustomRequest, res: Response, next: NextFunction) => {
   }
 
   try {
-    req.user = jwt.verify(bearerToken, process.env.ACCESS_TOKEN_SECRET!);
+    req.user = jwt.verify(
+      bearerToken,
+      process.env.ACCESS_TOKEN_SECRET!,
+    ) as JWTUserData;
     next();
   } catch (err) {
     return res.status(403).json({ message: "Invalid or expired token." });

--- a/server/middlewares/requestLogger.middleware.ts
+++ b/server/middlewares/requestLogger.middleware.ts
@@ -2,10 +2,10 @@ import morgan from "morgan";
 
 import logger from "utils/logger.util.ts";
 
-const morganLogger = morgan("combined", {
+const requestLogger = morgan("combined", {
   stream: {
     write: (message) => logger.http(message.trim()),
   },
 });
 
-export default morganLogger;
+export default requestLogger;

--- a/server/middlewares/user.handleAvatarUpload.middleware.ts
+++ b/server/middlewares/user.handleAvatarUpload.middleware.ts
@@ -1,0 +1,8 @@
+import multer from "multer";
+
+const storage = multer.memoryStorage();
+const upload = multer({ storage });
+
+const handleAvatarUpload = upload.single("avatar");
+
+export default handleAvatarUpload;

--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -5,9 +5,11 @@ type UserModel = Document & {
   password: string;
   firstName: string;
   lastName?: string;
-  avatar?: string;
-  refreshToken?: string;
+  avatar: string | null;
+  refreshToken: string | null;
 };
+
+export const PUBLIC_USER_FIELDS = "username firstName lastName avatar";
 
 const { Schema } = mongoose;
 
@@ -27,8 +29,14 @@ const userSchema = new Schema<UserModel>(
       required: true,
     },
     lastName: String,
-    avatar: String,
-    refreshToken: String,
+    avatar: {
+      type: String,
+      default: null,
+    },
+    refreshToken: {
+      type: String,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cloudinary": "^2.6.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
@@ -17,6 +18,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.12.1",
     "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.2",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.17.0",
     "yamljs": "^0.3.0",
@@ -29,6 +31,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/morgan": "^1.9.9",
+    "@types/multer": "^1.4.12",
     "@types/node": "^20.11.24",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/yamljs": "^0.2.34",

--- a/server/routes/auth.route.ts
+++ b/server/routes/auth.route.ts
@@ -6,6 +6,6 @@ const router = express.Router();
 router.post("/register", authController.register);
 router.post("/login", authController.login);
 router.post("/logout", authController.logout);
-router.post("/refreshToken", authController.refreshToken);
+router.post("/refresh-token", authController.refreshToken);
 
 export default router;

--- a/server/routes/users.route.ts
+++ b/server/routes/users.route.ts
@@ -1,0 +1,12 @@
+import express from "express";
+
+import updateUser from "controllers/users/updateUser.controller.ts";
+import getCurrentUser from "controllers/users/getCurrentUser.controller.ts";
+import handleAvatarUpload from "middlewares/user.handleAvatarUpload.middleware.ts";
+
+const router = express.Router();
+
+router.get("/current", getCurrentUser);
+router.patch("/:userId", handleAvatarUpload, updateUser);
+
+export default router;

--- a/server/schemas/auth.schema.ts
+++ b/server/schemas/auth.schema.ts
@@ -26,7 +26,6 @@ export const authSchema = {
       .string()
       .max(50, "Last name must not exceed 50 characters")
       .optional(),
-    avatar: z.string().url("Avatar must be a valid URL").optional(),
   }),
 
   login: z.object({
@@ -52,5 +51,3 @@ export const authSchema = {
     refreshToken: z.string(),
   }),
 };
-
-export type RegisterSchema = z.infer<typeof authSchema.register>;

--- a/server/schemas/user.schema.ts
+++ b/server/schemas/user.schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+const fileSizeLimit = 3 * 1024 * 1024; // 3MB
+
+const imageSchema = z
+  .instanceof(File)
+  .refine(
+    (file) =>
+      [
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/svg+xml",
+        "image/gif",
+      ].includes(file.type),
+    { message: "asdasdInvalid image file type" },
+  )
+  .refine((file) => file.size <= fileSizeLimit, {
+    message: "File size should not exceed 3MB",
+  })
+  .optional();
+
+export const userSchema = {
+  update: z
+    .object({
+      username: z
+        .string()
+        .min(4, "Username must be at least 4 characters long")
+        .max(20, "Username must not exceed 20 characters")
+        .regex(
+          /^[a-zA-Z0-9_]+$/,
+          "Username can only contain letters, numbers, and underscores",
+        )
+        .optional(),
+      firstName: z
+        .string()
+        .min(1, "First name is required")
+        .max(50, "First name must not exceed 50 characters")
+        .optional(),
+      lastName: z
+        .string()
+        .max(50, "Last name must not exceed 50 characters")
+        .optional(),
+      avatar: imageSchema,
+    })
+    .strict(),
+};

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,14 +3,12 @@ import mongoose from "mongoose";
 import app from "app.ts";
 import { PORT } from "configs/server.config.ts";
 import logger from "utils/logger.util.ts";
-import setupSwagger from "configs/swagger.config.ts";
 
 mongoose.connection.once("open", () => {
   logger.info("MongoDB connected");
 
   app.listen(PORT, () => {
     logger.info(`Server running at http://localhost:${PORT}`);
-    setupSwagger(app);
   });
 });
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,7 +10,8 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "outDir": "dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "files": ["global.d.ts"]
 }

--- a/server/utils/logger.util.ts
+++ b/server/utils/logger.util.ts
@@ -1,29 +1,49 @@
 import winston from "winston";
 
-const { combine, errors, colorize, timestamp, label, printf } = winston.format;
+const { combine, timestamp, printf, errors, colorize } = winston.format;
+
+const logFormat = combine(
+  timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
+  errors({ stack: true }),
+  printf(({ timestamp, level, message, stack, ...metadata }) => {
+    const metadataInfo =
+      Object.keys(metadata).length === 0 ? "" : JSON.stringify(metadata);
+    const messageInfo = stack || message;
+
+    return `[${timestamp}] [${level}]: ${messageInfo} ${metadataInfo}`;
+  }),
+);
 
 const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || "info",
-  format: combine(
-    label({ label: "SERVER", message: true }),
-    colorize(),
-    errors({ stack: true }),
-    timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-    printf(({ timestamp, level, message, stack }) => {
-      return `[${timestamp}] [${level}]: ${stack || message}`;
+  level: process.env.LOG_LEVEL || "http",
+  transports: [
+    new winston.transports.File({
+      filename: "logs/standard.log",
+      format: logFormat,
     }),
-  ),
-  transports: [new winston.transports.File({ filename: "logs/standard.log" })],
-  exceptionHandlers: [
-    new winston.transports.File({ filename: "logs/exceptions.log" }),
   ],
   rejectionHandlers: [
-    new winston.transports.File({ filename: "logs/rejections.log" }),
+    new winston.transports.File({
+      filename: "logs/rejections.log",
+      format: logFormat,
+    }),
+  ],
+  exceptionHandlers: [
+    new winston.transports.File({
+      filename: "logs/exceptions.log",
+      format: logFormat,
+    }),
   ],
 });
 
 if (process.env.NODE_ENV !== "production") {
-  logger.add(new winston.transports.Console());
+  logger.add(
+    new winston.transports.Console({
+      format: combine(colorize(), logFormat),
+      handleExceptions: true,
+      handleRejections: true,
+    }),
+  );
 }
 
 export default logger;


### PR DESCRIPTION
Added a couple of new User endpoints. View the updated swagger docs to see all the details.

Required changes from frontend side:
- Cloudinary: 
  - add the secrets into your .env file
  - accept the email invitation to view the assets on web service
- The endpoint for token refresh is now called `api/auth/refresh-token` instead of `api/auth/refreshToken`. Please change this in your requests 